### PR TITLE
testing_html - fixing syntax plus editorial

### DIFF
--- a/duckduckhack/testing/testing_html.md
+++ b/duckduckhack/testing/testing_html.md
@@ -1,54 +1,53 @@
 # Testing HTML
 
-You should have already tested your Spice triggers by following the [Testing triggers](https://github.com/duckduckgo/duckduckgo#testing-triggers) section. Once you're confident your triggers are functioning properly, follow these steps to see your Spice instant answer on a live server!
+You should have already tested your triggers by following the [Testing triggers](https://github.com/duckduckgo/duckduckgo#testing-triggers) section. Now that you're confident your triggers are functioning properly, follow these steps to see how it looks on a live server!
 
 1. Go to the root of your forked repository.
 
-  ```shell
-  cd zeroclickinfo-spice/
-  ```
+  For example:
+
+    ```shell
+    cd zeroclickinfo-spice/
+    ```
 
 2. Start the server.
 
-  ```shell
-  duckpan server
-  ```
+    ```shell
+    duckpan server
+    ```
 
-  This command will start up a small Web server running on port 5000 on your machine.
+    This command will start up a small Web server running on port 5000.
 
 3. Visit the server in your browser.
 
-  You should now be able to go to your duckpan server via a regular Web browser and check it out. It runs code from our site and so generally looks like a real version of DuckDuckGo. 
+    If you are running the duckpan server on your local computer, you can navigate to:
 
-  If you're running the duckpan server on the same computer as your Web browser you can navigate to:
+    [http://127.0.0.1:5000/](http://127.0.0.1:5000/)
 
-  ```shell
-  http://127.0.0.1:5000/
-  ```
+    Replace 127.0.0.1 with your server's IP address or Fully Qualified Domain Name if you have started the duckpan server remotely.
 
-  If you're running the duckpan server on a remote machine, then substitute 127.0.0.1 with either its IP address or its Fully Qualified Domain Name.
+    You should now be able to browse your duckpan server and see live results. The server runs code from our site which should make it look very much like the real DuckDuckGo.
 
 4. Search.
 
-  Given you've already tested your instant answer's triggers, you should be able to search and see your spice output come through the server. As requests go through the internal Web server, they are printed to STDOUT (on the screen). External API calls are highlighted (if you have color turned on in your terminal).
+    Having already tested your triggers, you should be able to construct a query to hit that trigger and see your newly defined result. Information about the processing of your requests is printed to the terminal where you started the server. Any external API calls will be highlighted if supported by your terminal.
 
 5. Debug.
 
-  If for some reason a search doesn't hit an instant answer, there is an error message displayed on the homepage saying "Sorry, no hit for your instant answer." 
+    If your search doesn't hit an instant answer, there will be an error message displayed on the page: "Sorry, no hit for your instant answer."
 
-  If it does hit and you do not see something displayed on the screen, a number of things could be going wrong.
+  If the trigger is hit but you do not see something displayed on the screen, a number of things could be wrong:
 
-  - You have a JavaScript error of some kind. Check out the JavaScript console for details. Personally we like to use [Firebug](http://getfirebug.com/) internally.
+    - You have a JavaScript error of some kind. Internally, we like to use the JavaScript console in [Firebug](http://getfirebug.com/) to get more details.
 
-  - The external API was not called correctly. You should be able to examine the Web server output to make sure the right API is being called. If it's not you will need to revise your [Spice handle function](#spice-handle-functions).
+    - An external API was not called correctly. You should examine the Web server output to make sure the correct API is being called. If it's not you will need to revise your [Spice handle function](#spice-handle-functions).
 
-  - The external API did not return anything. Firebug is great for checking this as well. You should see the call in your browser and then you can examine the response.
-
+    - An external API did not return anything. Firebug is a great help here, as well. You should be able to see the external call in your browser and examine the response.
 
 6. Tweak the display.
 
-  Once everything is working properly (and you have stuff displayed on screen), you will want to mess with your callback function to get the display nice and perfect. Check out the [Guidelines](https://github.com/duckduckgo/duckduckgo#guidelines) for some pointers.
+    Once all of the processing is working properly, you will probably want to adjust your callback function to get the display just right. The [Guidelines](https://github.com/duckduckgo/duckduckgo#guidelines) have some pointers to help you along.
 
-7. Document. 
+7. Document.
 
-  Finally, please document as much as possible using in-line comments.
+    Please document your code as appropriate using in-line comments.


### PR DESCRIPTION
- Fixed some markdown indentation for better rendering.
- Updated localhost URL to a link for convenience.
- Toned down mentions of Spice, since this page is linked from and
  provided in non-Spice-specific places. Hopefully, the transition is
  not as jarring.

As is my wont, also includes other editorial changes since I was here
and doing edits, anyway.

This is a cleaned-up and checked-in-publisher version of my previous pull request.  I had no idea markdown could be so complicated.
