### PR TITLE
location_api: various bits of requested text clean-up

### DIFF
--- a/duckduckhack/advanced/location_api.md
+++ b/duckduckhack/advanced/location_api.md
@@ -1,10 +1,10 @@
 # Location API
 
-Some instant answers need the user's location to provide the most relevant results. For example, since weather conditions vary the world over, the [Is it snowing?](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Snow.pm) instant answer depends on knowing where the user is located.
+Some instant answers need the user's location to provide the most relevant results. For example, since weather conditions vary widely around the world, the [Is it snowing?](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Snow.pm) instant answer depends on knowing where the user is located.
 
-The [core DDG package](https://github.com/duckduckgo/duckduckgo) provides a Location API. Since Goodie and Spice instant answers inherit from this package, their `handle` functions have access to a `$loc` variable which refers to a [Location object](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Location.pm).
+The [core DDG library](https://github.com/duckduckgo/duckduckgo) provides a Location API. Since Goodie and Spice instant answers inherit from this package, their `handle` functions have access to a `$loc` variable which refers to a [Location object](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Location.pm).
 
-This Location object has a number of [useful attributes](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Location.pm#L6) to help you provide revelant answers:
+This Location object has a number of [useful attributes](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Location.pm#L6) to help you provide relevant answers:
 
 ```perl
 my @geo_ip_record_attrs = qw( country_code country_code3 country_name region
@@ -37,6 +37,6 @@ When testing instant answers interactively with `duckpan`, the location will alw
 my $location = join(", ", $loc->city, $loc->region_name, $loc->country_name);
 ```
 
-For assistance with setting the location to be used in automated testing, please refer to the guide to [testing with the Location API](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/testing_location_api.md).
+For assistance with setting the location to be used in automated testing, please refer to the [Location API testing guide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/testing_location_api.md).
 
 Naturally, once your instant answer is live, `$loc` will refer to the appropriate location.


### PR DESCRIPTION
- Replace the "vary the world over" colloquialism with "vary
  widely around the world"
- "core DDG package" becomes "core DDG library"
- "Revelant" is a pretty sweet word.. but "relevant" is what
  was meant.
- Make link to API testing guide read less clumsily.
