### PR TITLE
Expand fathead documentation

### DIFF
--- a/duckduckhack/fathead/fathead_overview.md
+++ b/duckduckhack/fathead/fathead_overview.md
@@ -1,6 +1,8 @@
 # Fathead Instant Answers
 
-Each Fathead instant answer is powered by a simple database. When the instant answer is triggered, the corresponding row from the database is returned, using a single template for all Fathead instant answers. Your job, as the author of an instant answer, is to write a program that generates the database, known as output.txt. The program may be written in any reasonable language, and will be run periodically to keep the database current.
+Fatheads are key-value instant answers backed by a database. The keys of the database are typically words or phrases, and they are also used as the triggers for the instant answer. When a database key is queried, the corresponding row from the database is returned, which is typically a paragraph of text. Developing a Fathead instant answer entails writing a program that generates an ``output.txt`` file. This tab-delimited file indicates the keys and values for the database, as well as some other important information discussed below. The program may be written in any reasonable language, and if necessary, will be run periodically to keep the database current.
+
+The "output.txt" file that is generated will be consumed by the DuckDuckGo backend, cleaned up (details below) and then finally entered into an SQL database.
 
 ## Structure
 


### PR DESCRIPTION
I changed the big code blocks into some prettier lists and added an intro section.

I may have missed some details, but I think it's better than it was before.
