### PR TITLE
add rowHighligh to docs

### DIFF
--- a/duckduckhack/spice/spice_templates_overview.md
+++ b/duckduckhack/spice/spice_templates_overview.md
@@ -444,6 +444,7 @@ templates: {
     group: 'base',
     options: {
         content: 'record',
+        /* optional - highlight alternate rows */
         rowHighlight: true
     }
 }


### PR DESCRIPTION
Added `rowHighlight` for the record template. 
cc @moollaza 
