### PR TITLE
ddh-intro: add vertical space for list.

### DIFF
--- a/duckduckhack/getting-started/ddh-intro.md
+++ b/duckduckhack/getting-started/ddh-intro.md
@@ -12,6 +12,7 @@ In the above example, Quixey was a source recommended by our community for searc
 
 Anyone in the world can help improve the search experience on DuckDuckGo. Whether you can code or not, there are many ways for you to contribute. You can get started by suggesting new instant answers to the community, recommending better data sources, or actually hacking away on your own instant answer.
 <!-- /summary -->
+
 1. **Suggesting Instant Answer Ideas**
 
   On DuckDuckGo, searches like ["what is the height of the eiffel tower"](https://duckduckgo.com/?q=what+is+the+height+of+the+eiffel+tower) will show you that it's exactly 1063 feet tall, while ["currently in theaters"](https://duckduckgo.com/?q=currently+in+theaters) will show you what's actually playing in nearby movie theaters.  We depend on suggestions from users like yourself to know what sort of useful instant answers you want from your search engine.


### PR DESCRIPTION
The addition of the `<!-- /summary -->` line seems to have confused the MarkDent processor which is quite flaky about the vertical whitespace.

I have tested this change in publisher and now get the correct rendering, but I don't know if:
- this breaks something else which depends on that hidden tag, or
- there are other places with wonky rendering because of the new summary tagging.

cc: @jdorweiler 
