### PR TITLE
Add linebreaks before perl blocks.

### DIFF
--- a/duckduckhack/testing/advanced_testing.md
+++ b/duckduckhack/testing/advanced_testing.md
@@ -9,6 +9,7 @@ For example, if the name of your instant answer was **Chars**, the file would be
 
 The top of the file reads like a normal Perl script with some use statements to include testing modules, including the DuckDuckGo testing module.
 <!-- /summary -->
+
 ```perl
 #!/usr/bin/env perl
 

--- a/duckduckhack/testing/goodie_tests.md
+++ b/duckduckhack/testing/goodie_tests.md
@@ -2,6 +2,7 @@
 
 For this example, we will look at the test file of the **RouterPasswords** Goodie, which is `t/RouterPasswords.t` [(link)](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/t/RouterPasswords.t).
 <!-- /summary -->
+
 ```perl
 #!/usr/bin/env perl
 


### PR DESCRIPTION
Considering the difficulty we've had I used a script to identify likely
places where perl-quoted blocks did not follow an empty line.  These two
places were identified.  Only one of them appears to be rendering
incorrectly live which simply adds to my confusion.

Regardless, I tried some additional checks for txt/shell/bash blocks and
did not find any others.  This does not mean that they do not exist.
