### PR TITLE
add newlines around all summary tags

### DIFF
--- a/duckduckhack/advanced/location_api.md
+++ b/duckduckhack/advanced/location_api.md
@@ -1,7 +1,9 @@
 ## Location API
 
 Some instant answers need the user's location to provide the most relevant results. For example, since weather conditions vary widely around the world, the [Is it snowing?](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Snow.pm) instant answer depends on knowing where the user is located.
+
 <!-- /summary -->
+
 The [core DDG library](https://github.com/duckduckgo/duckduckgo) provides a Location API. Since Goodie and Spice instant answers inherit from this package, their `handle` functions have access to a `$loc` variable which refers to a [Location object](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Location.pm).
 
 This Location object has a number of [useful attributes](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Location.pm#L6) to help you provide relevant answers:

--- a/duckduckhack/getting-started/determine_your_instant_answer_type.md
+++ b/duckduckhack/getting-started/determine_your_instant_answer_type.md
@@ -13,7 +13,9 @@ Most instant answers rely on some type of data source to provide their answer; h
 Please use the following flowchart to help you to determine which kind of instant answer you'll be creating. Your instant answer type will be based on the date source your instant answer will be using:
 
 ![instant answer type flow chart](https://raw.github.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/instant_answer_flowchart.png)
+
 <!-- /summary -->
+
 If you were able to determine which instant answer type you will be using, please continue below to fork the repository so you can begin coding!
 
 If the right instant answer type is still not obvious, don't worry, the DuckDuckGo community is here for you! Please visit our [instant answer idea forum](https://dukgo.com/forum) and post a new thread for your instant answer. Be sure to describe the instant answer you have in mind, and don't forget to indicate where you think the data should come from. Someone from the community or the DuckDuckGo team will be able to help you determine the best course of action for you.

--- a/duckduckhack/getting-started/whatsnew.md
+++ b/duckduckhack/getting-started/whatsnew.md
@@ -80,7 +80,9 @@ Template groups:
 Tiles support title, subtitle, and content and footer sub templates which the IA can provide.
 
 ![github using text group, showing tiles](https://raw.github.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/github_duckduckgo.png)
+
 <!-- /summary -->
+
 [github](https://github.com/duckduckgo/zeroclickinfo-spice/tree/bttf/share/spice/github) using the text template group with a custom footer
 
 ------
@@ -101,7 +103,9 @@ Similar to text but with an embedded small image in the upper right. Title, desc
 Info is a sophisticated template for showing summary information with an optional image and embedded auxiliary box. Both the text and auxiliary box are expandable, by default showing four lines of text in height. Both the text and the auxiliary box can contain arbitrary content by using an IA-defined template.
 
 ![Last.fm using the info template](https://raw.github.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/artist.png)
+
 <!-- /summary -->
+
 The info template also supports an embedded auxiliary box on the right.
 There's an [open issue for Last.fm](https://github.com/duckduckgo/zeroclickinfo-spice/issues/684) to display the artist's top tracks in the auxiliary box.
 
@@ -117,7 +121,9 @@ Because Drinks doesn't have an image, it's not shown and the text is aligned lef
 The products template group consists of templates for tiles and detail that are structured for items that can be bought. Rating, brand, and price are a few of the things that we need. There is a second group called `products_simple` which is similar but with the price and brand turned off by default, and a slightly simpler tile structure.
 
 ![amazon using the products group](https://raw.github.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/products_detail.png)
+
 <!-- /summary -->
+
 ------
 
 ![Tile comparison: variations of 'products'](https://raw.github.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/tile_comparison.png)

--- a/duckduckhack/goodie/goodie_advanced_handle_functions.md
+++ b/duckduckhack/goodie/goodie_advanced_handle_functions.md
@@ -20,7 +20,9 @@ handle remainder => sub {
 Goodies can use simple text or html input files for display or processing. These files can be read once and reused to answer many queries without cluttering up your source code.
 
 The `share` function gives each instant answer access to a subdirectory of the repository's `share` directory. The subdirectory for your instant answer is based on its Perl package name which is transformed from CamelCase to underscore_separated_words.  For example, the [DDG::Goodie::RegexCheatSheet package](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/RegexCheatSheet.pm) uses the directory [share/goodie/regex_cheat_sheet](https://github.com/duckduckgo/zeroclickinfo-goodies/tree/master/share/goodie/regex_cheat_sheet) to store its custom CSS.
+
 <!-- /summary -->
+
 Meanwhile, the [Passphrase Goodie](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Passphrase.pm) uses the `share` directory to hold data for processing purposes:
 
 ```perl

--- a/duckduckhack/goodie/goodie_basic_tutorial.md
+++ b/duckduckhack/goodie/goodie_basic_tutorial.md
@@ -1,7 +1,9 @@
 ## Basic Goodie Tutorial
 
 In this tutorial, we'll be making a Goodie instant answer that checks the number of characters in a given search query. The end result  works [like this](https://duckduckgo.com/?q=chars+How+many+characters+are+in+this+sentence%3F) and will look like this:
+
 <!-- /summary -->
+
 ###### chars.pm
 
 ```perl
@@ -28,7 +30,9 @@ To begin, open your favourite text editor like [gedit](http://projects.gnome.org
 package DDG::Goodie::Chars;
 # ABSTRACT: Give the number of characters (length) of the query.
 ```
+
 <!-- /summary -->
+
 Each instant answer is a [Perl package](https://duckduckgo.com/?q=perl+package), so we start by declaring the package namespace. For a new Goodie (or any new instant answer), you would change **Chars** to the name of the instant answer (written in [CamelCase](https://duckduckgo.com/?q=camelcase) format).
 
 The second line is a special comment line that is used for documentation purposes.
@@ -70,7 +74,9 @@ handle remainder => sub {
 Once triggers are specified, we define how to *handle* the query. `handle` is another keyword, similar to **triggers**.
 
 You can *handle* different parts of the search query, but the most common is the **remainder**, which refers to the remainder of the query, after the first matched trigger word/phrase has been removed. 
+
 <!-- /summary -->
+
 For example, if the query was "**chars this is a test**", the trigger would be *chars* and the remainder would be *this is a test*.
 
 Now let's add a few more lines to complete the handle function:

--- a/duckduckhack/goodie/goodie_triggers.md
+++ b/duckduckhack/goodie/goodie_triggers.md
@@ -9,7 +9,9 @@ There are two types of triggers, **words** and **regex**. We insist that you use
 ```perl
 triggers <location> => <array of words and phrases>
 ```
+
 <!-- /summary -->
+
 #### Examples
 
 ```perl
@@ -46,7 +48,9 @@ triggers end => "ending phrase of query";
 ```perl
 triggers <query_format> => <regular expression>
 ```
+
 <!-- /summary -->
+
 #### Examples
 
 ```perl

--- a/duckduckhack/spice/spice_advanced_backend.md
+++ b/duckduckhack/spice/spice_advanced_backend.md
@@ -36,7 +36,9 @@ handle remainder => sub {
   return;
 }
 ```
+
 <!-- /summary -->
+
 Then the the string `10-100` would be sent to the `spice from` regexp, which would capture the two numbers into `$1` and `$2`. These two placeholders are then used to replace `$1` and `$2` in the `spice to` URL:
 
 ```perl
@@ -102,7 +104,9 @@ The return of **call** will run whatever is in the **call\_type** setting. **sel
 ## Caching
 
 Spice instant answers have two forms of caching: API Response caching (remembers the JSON returned from the API) and API Call caching (remembers the API call URL created for a given query). Both of these will be explained with examples.
+
 <!-- /summary -->
+
 ### Caching API Responses
 
 By default, we cache API responses for for **24 hours**. We use [nginx](https://duckduckgo.com/?q=nginx) and get this functionality by using the [proxy_cache_valid](http://wiki.nginx.org/HttpProxyModule#proxy_cache_valid) directive. You can override our default behavior by setting your own `spice proxy_cache_valid` directive like in the [RandWord Spice](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/RandWord.pm):

--- a/duckduckhack/spice/spice_basic_tutorial.md
+++ b/duckduckhack/spice/spice_basic_tutorial.md
@@ -1,7 +1,9 @@
 ## Basic Spice Tutorial
 
 In this tutorial, we'll be making a Spice instant answer that lets you search for Node.js packages, using the [Node Packaged Modules API](http://registry.npmjs.org/uglify-js/latest). The end result works [like this](https://next.duckduckgo.com/?q=npm+http-server) and the first part, the "backend" component, will look like this:
+
 <!-- /summary -->
+
 # NPM Spice - Backend (Perl)
 
 ###### Npm.pm
@@ -33,7 +35,9 @@ To begin, open your favorite text editor like [gedit](http://projects.gnome.org/
 package DDG::Spice::Npm;
 # ABSTRACT: Returns package information from npm package manager's registry.
 ```
+
 <!-- /summary -->
+
 Each instant answer is a [Perl package](https://duckduckgo.com/?q=perl+package), so we start by declaring the package namespace. For a new Spice (or any new instant answer), you would change **npm** to the name of the instant answer (written in [CamelCase](https://duckduckgo.com/?q=camelcase) format).
 
 The second line is a special comment line that is used for documentation purposes.
@@ -57,7 +61,9 @@ triggers startend => 'npm';
 ```
 
 **triggers** are keywords/phrases that tell us when to make the instant answer run. When a particular *trigger word* (or phrase) is part of a search query, it tells DuckDuckGo to *trigger* the instant answer(s) that have indicated they should trigger for the given word (or phrase).
+
 <!-- /summary -->
+
 In this case there is one trigger word: "**npm**". 
 
 Let's say someone searched "**npm uglify-js**". "**npm**" is the *first* word, so it would trigger our Spice because the **startend** keyword says, "Make sure the *trigger word* is at the *start*, or the *end*, of the query." 
@@ -73,7 +79,9 @@ spice to => 'http://registry.npmjs.org/$1/latest';
 ```
 
 The **spice to** attribute indicates the API endpoint we'll be using, which means a `GET` request will be made to this URL. The URL has a **$1** placeholder, which will eventually be replaced with whatever string our `handle` function (which we'll define shortly) returns. Generally, Spice instant answers use a search endpoint for a given API and so, we'll need to pass along our search term(s) in the API request. We do this by returning the desired search terms in the `handle` function and then the **$1** placeholder, in the `spice to` URL, will be replaced accordingly.
+
 <!-- /summary -->
+
 Using the previous example, if we wanted to search for "**uglify-js**" with the NPM API, we'd need to replace `$1` with `uglify-js` which would result in this URL: <http://registry.npmjs.org/uglify-js/latest>. If you follow that link, you'll notice the API returns a JSON object containing all the data pertaining to the "uglify-js" NPM Package.
 
 ## Indicate our Callback Function
@@ -89,7 +97,9 @@ This parameter is used to wrap the JSON object being returned, in a JavaScript f
 ```perl
 spice wrap_jsonp_callback => 1;
 ```
+
 <!-- /summary -->
+
 Now, when the JSON is returned by the API, it will be wrapped in a call to our Spice's JavaScript callback function, which we'll define later.
 
 ------
@@ -115,7 +125,9 @@ handle remainder => sub {
 Once triggers are specified, we define how to *handle* the query. `handle` is another keyword, similar to **triggers**.
 
 You can *handle* different parts of the search query, but the most common is the **remainder**, which refers to the remainder of the query, after the first matched trigger word/phrase has been removed. 
+
 <!-- /summary -->
+
 For example, if the query was "**npm uglify-js**", the trigger would be *npm* and the **remainder** would be *uglify-js*.
 
 Now let's add a few more lines to complete the handle function:
@@ -233,7 +245,9 @@ Let's go through it line-by-line:
 (function (env) {
     "use strict";
 ```
+
 <!-- /summary -->
+
 We begin by invoking an anonymous, immediately-executing function, which takes an object as input (i.e. the environment). This is better known as the JavaScript "[Module Pattern](http://www.addyosmani.com/resources/essentialjsdesignpatterns/book/#modulepatternjavascript)" and it ensures that any variables or functions created within our anonymous function do not affect the global scope. It also allows us to explicitly import anything from the outside environment, which we use to pass along the global scope into our `env` variable (you'll see this at the end), so we can still access and modify the global scope as needed. After creating our module, we then we turn on JavaScript's [Strict Mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FFunctions_and_function_scope%2FStrict_mode) which also offers various benefits. You don't really need to understand the purpose of these first two lines to create a Spice instant answer; however, they're both necessary and must be included when defining a Spice callback function.
 
 ## Define our Callback Function
@@ -241,7 +255,9 @@ We begin by invoking an anonymous, immediately-executing function, which takes a
 ```javascript
     env.ddg_spice_npm = function (api_result) {
 ```
+
 <!-- /summary -->
+
 We now define our callback function, `ddg_spice_npm`, using a function expression and set it as a property of the `env` object that was passed into our anonymous function. The name we specify here ***must*** match the name of our Spice package, which we discussed above. We also specify that the callback function takes one input parameter, which we have named `api_result`. All Spice callback functions should look like this. The name for the input should **always** be called `api_result`. This is part of our naming convention and helps to standardize the JavaScript code.
 
 ## Validate our API Response
@@ -253,7 +269,9 @@ We now define our callback function, `ddg_spice_npm`, using a function expressio
             return Spice.failed('npm');
         }
 ```
+
 <!-- /summary -->
+
 Here we specify that if the `error` property in the API result is defined (meaning there are no results to use) we `return` a call to `Spice.failed('npm')`, which stops the execution of the function and as a result, won't display an instant answer. It's important to use `Spice.failed();` because this lets the rest of the Spice system know our Spice isn't going to display so that other relevant answers can be given an opportunity to display.
 
 In other cases, because most APIs return an array of results, a similar check should be made to see if the results array has a `length`. This way, if no results were returned from the API we can stop and display nothing.
@@ -284,7 +302,9 @@ Moving on, the next part is very important, it defines how the Spice result shou
 ```
 
 Here we make a call to the `Spice.add()` function, which operates on an input object that we normally define inside the function call. Let's go over each of the parameters specified in the object we give to `Spice.add()`:
+
 <!-- /summary -->
+
 - `id` is the unique identifier for your Spice instant answer, as convention, we use the name of the spice, just like we do for the callback function.
 
 - `name` is the text to be used for the Spice's AnswerBar tab.
@@ -319,7 +339,9 @@ Lastly, we close our callback function expression, as well as our module, and we
 ## Define our Handlebars Template
 
 At this point, the rendering of the Spice instant answer changes context from JavaScript to Handlebars.js. As mentioned, our `Spice.add()` call specifies our template and the **context** for the template, so now `Spice.add()` executes the template function using `data` as the input. Let's look at the NPM instant answer's Handlebars template to see how it displays the instant answer result:
+
 <!-- /summary -->
+
 ###### detail.handlebars
 
 ```html

--- a/duckduckhack/spice/spice_overview.md
+++ b/duckduckhack/spice/spice_overview.md
@@ -20,7 +20,9 @@ Aside from HTML and CSS, the Spice frontend also utilizes the following third-pa
 - and [Handlebars](http://handlebarsjs.com) v1.3.0
 
 If you're not already familiar with Handlebars, *please* read the [Handlebars documentationn](http://handlebarsjs.com) before continuing on. Don't worry if you don't fully understand how to use Handlebars, the examples will explain everything. You should, at the very least, familiarize yourself with Handlebars concepts and terminology before moving on. It should only take a few minutes to read!
+
 <!-- /summary -->
+
 Likewise, using jQuery is not required for making a Spice instant answer. But, it does offer certain benefits, such as cross-browser compatible implementations of various JavaScript functions. For example, jQuery's `$.each()` should be used in place of the native `Array.prototype.forEach()`, as it does **not** work in IE 6,7,8.
 
 Later, we will walk you through several examples, ranging from simple to complex, which will explain how to use templates and make your instant answers look awesome :)

--- a/duckduckhack/spice/spice_templates_overview.md
+++ b/duckduckhack/spice/spice_templates_overview.md
@@ -9,7 +9,9 @@ There are several built-in Spice templates (both item and detail) which can be u
 - [Tile Variants](#tile-variants)  Used to modify width of the tiles
 
 There are several built-in Spice templates (both `item` and `detail`) which can be used for any Spice. Most of these templates however have similar or related elements and work well together (i.e. pairings of `item` and `detail` templates). As a result, we have defined various **template groups** which **we highly recommend you use** because using a particular group tells the Spice system which built-in templates will be used for your Spice. Template groups also have various features enabled by default which you can easily modify using the `options` block.
+
 <!-- /summary -->
+
 For example, the `media` **template group** works well when your Spice is related to "thing" (e.g., recipe, tv show, movie, game) which has an image to display, a name, and a rating. It's likely that this template group will work for other types of results and we're here to help you determine which template group and features work best for your Spice instant answer.
 
 The purpose of this page is to help you understand what each template group looks like and what content works best for it. Each group is accompanied by several examples of live Spice instant answers using that group. Each template is accompanied by similar examples, links to code and diagrams indicating what features exist for the template and what the template layout looks like.
@@ -96,7 +98,9 @@ templates: {
     group: 'text'
 }
 ```
+
 <!-- /summary -->
+
 When you specify this template group, it is equivalent to setting the properties of the `templates` block as follows:
 
 ```javascript
@@ -146,7 +150,9 @@ templates: {
     group: 'info'
 }
 ```
+
 <!-- /summary -->
+
 When you specify this template group, it is equivalent to setting the properties of the `templates` block as follows:
 
 ```javascript
@@ -200,7 +206,9 @@ templates: {
     group: 'products'
 }
 ```
+
 <!-- /summary -->
+
 When you specify this template group, it is equivalent to setting the properties of the `templates` block as follows:
 
 ```javascript
@@ -260,7 +268,9 @@ templates: {
     group: 'media'
 }
 ```
+
 <!-- /summary -->
+
 When you specify this template group, it is equivalent to setting the properties of the `templates` block as follows:
 
 ```javascript
@@ -321,7 +331,9 @@ templates: {
     group: 'icon'
 }
 ```
+
 <!-- /summary -->
+
 When you specify this template group, it is equivalent to setting the properties of the `templates` block as follows:
 
 ```javascript
@@ -367,7 +379,9 @@ templates: {
     group: 'base'
 }
 ```
+
 <!-- /summary -->
+
 When you specify this template group, it is equivalent to setting the properties of the `templates` block as follows:
 
 ```javascript
@@ -425,13 +439,17 @@ The list of built-in Spice templates includes:
 - [base_detail](#basedetail-template)
 
 ------
+
 <!-- /summary -->
+
 ## record template
 
 A special template that is ideal for key-value data. It generates a `<table>` where each row contains a key and value.
 
 **\*\*Note:** This template **requires** that your `data` object has a `record_data` property, which should contain the key-value data to be displayed. All the properties of the `record_data` object will be used as the keys for the table. However, if you want to specify exactly which properties of the `record_data` object should be displayed, an optional `record_keys` property can be defined. It should be an array of *strings*, indicating the names of the **keys** to be included in the `<table>`.  An optional property called `rowHighlight` can be added to `options` to turn on alternating row highlighting. 
+
 <!-- /summary -->
+
 For example this is how your Spice code should look when using the **record** template:
 
 ```javascript
@@ -490,7 +508,9 @@ templates: {
 ### Template Diagram
 
 ![icon template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/icon.png)
+
 <!-- /summary -->
+
 ### Template groups using the "icon_item" template:
 
 - [icon](#icon-template-group)
@@ -514,7 +534,9 @@ templates: {
 ### Template Diagram
 
 ![text_item template ](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/text_item.png)
+
 <!-- /summary -->
+
 ### Template groups using the "text_item" template:
 
 - [text](#text-template-group)
@@ -538,7 +560,9 @@ templates: {
 ### Template Diagram
 
 ![text_detail template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/text_detail.png)
+
 <!-- /summary -->
+
 ### Template groups using the "text_detail" template:
 
 - [text](#text-template-group)
@@ -564,7 +588,9 @@ templates: {
 ### Template Diagram
 
 ![basic_image_item template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/basic_image_item.png)
+
 <!-- /summary -->
+
 ### Template groups using the "basic_image_item" template:
 
 - [info](#info-template-group)
@@ -592,7 +618,9 @@ templates: {
 ### Template Diagram
 
 ![products_item template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/products_item.png)
+
 <!-- /summary -->
+
 ### Template groups using the "products_item" template:
 
 - [products](#products-template-group)
@@ -623,7 +651,9 @@ templates: {
 ### Template Diagram
 
 ![products_detail template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/products_detail.png)
+
 <!-- /summary -->
+
 ### Template groups using the "products_detail" template:
 
 - [products](#products-template-group)
@@ -654,7 +684,9 @@ templates: {
 ### Template Diagram
 
 ![products_item_detail template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/products_item_detail.png)
+
 <!-- /summary -->
+
 ### Template groups using the "products_item_detail" template:
 
 - [products](#products-template-group)
@@ -682,7 +714,9 @@ templates: {
 ### Template Diagram
 
 ![basic_info_detail template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/basic_info_detail.png)
+
 <!-- /summary -->
+
 ### Example with Auxiliary Information Box:
 
 ![basic_info_detail_w_aux template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/basic_info_detail_w_aux.png)
@@ -709,7 +743,9 @@ templates: {
 ### Template Diagram
 
 ![base_item template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/base_item.png)
+
 <!-- /summary -->
+
 ### Complex Example
 
 ![base_item template (complex example)](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/base_item_complex.png)
@@ -734,7 +770,9 @@ templates: {
 ### Template Diagram
 
 ![base_detail template](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/base_detail.png)
+
 <!-- /summary -->
+
 ### Complex Example
 
 ![base_detail template (complex example)](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/diagrams/base_detail_complex.png)
@@ -778,7 +816,9 @@ templates: {
     }
 }
 ```
+
 <!-- /summary -->
+
 ### Examples
 
 - ["the dark knight movie"](https://duckduckgo.com/?q=the+dark+knight+movie)
@@ -801,7 +841,9 @@ templates: {
     }
 }
 ```
+
 <!-- /summary -->
+
 ### Examples
 
 - ["alarm clock apps"](https://duckduckgo.com/?q=alarm+clock+apps)
@@ -824,7 +866,9 @@ templates: {
     }
 }
 ```
+
 <!-- /summary -->
+
 ### Examples
 
 none...*yet!*

--- a/duckduckhack/spice/spice_triggers.md
+++ b/duckduckhack/spice/spice_triggers.md
@@ -22,7 +22,9 @@ triggers start => "trigger my instant answer", "trigger myIA", "myIA";
 ```perl
 triggers <location> => <array of words and phrases>
 ```
+
 <!-- /summary -->
+
 #### Examples
 
 ```perl
@@ -59,7 +61,9 @@ triggers end => "ending phrase of query";
 ```perl
 triggers <query_format> => <regular expression>
 ```
+
 <!-- /summary -->
+
 #### Examples
 
 ```perl
@@ -86,7 +90,9 @@ triggers query_raw => $regex;
 ## Regex Guards
 
 We much prefer you use **trigger words** when possible because they are faster on the backend. In some cases however, **regular expressions** are necessary, e.g. you need to trigger on sub-words. In this case we suggest you consider using a **word trigger** and supplement it with a **regex guard**. A regex guard is a return clause immediately inside the `handle` function.
+
 <!-- /summary -->
+
 A good example of this is the Base64 goodie. In this case we want to trigger on queries with the form "base64 encode/decode \<string\>". Here's an excerpt from [Base64.pm](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Base64.pm) which shows how this case is handled using a word trigger, with a regex guard:
 
 ```perl

--- a/duckduckhack/styleguides/design_styleguide.md
+++ b/duckduckhack/styleguides/design_styleguide.md
@@ -27,7 +27,9 @@ When designing an instant answer there are a few key concepts to keep in mind:
 ## Continuity
 
 All instant answers, regardless of their type (Spice, Goodie, Fathead or Longtail) should maintain visual design continuity. This means that the styling and placement of the Instant Answer Box elements should be the same for all instant answers. The following design elements should remain consistent across all instant answers:
+
 <!-- /summary -->
+
 - #### Instant Answer Width
   
   The width of instant answers is automatically calculated based on the users screen size and should not be modified. Individual users are able to change the width of the SERP by modifying their settings.
@@ -63,7 +65,9 @@ All instant answers, regardless of their type (Spice, Goodie, Fathead or Longtai
 ## Simplicity
 
 Aside from continuity, all instant answers should also be designed with simplicity in mind. The information an instant answer provides is the most important part, which means that it should be:
+
 <!-- /summary -->
+
 - #### Easy to Find
   
   Instant answers should be easy to find, which is why we keep them at the top of the page and the actual answer to the question, whether it's text, an image, a table, etc., should be easy to find within the Instant Answer Box. An instant answer's content should be succinct and to-the-point. Sentence form is preferred when feasible; however, large paragraphs of text should be avoided.

--- a/duckduckhack/styleguides/styleguide_overview.md
+++ b/duckduckhack/styleguides/styleguide_overview.md
@@ -4,7 +4,9 @@
 - [Code Style Guide](http://duck.co/duckduckhack/code_styleguide) 
 
 At DuckDuckGo we aim to make our instant answers highly informative and simple to use. This means that only the most relevant information should be included in instant answer results and the user should be able to immediately understand what they are looking at.
+
 <!-- /summary -->
+
 We also strive to ensure all our instant answers are designed and built with a focus on consistency. This means we maintain certain visual aspects across all of our instant answers such as the fonts and colors used, as well as the layout and placement of common elements, like the maximize/minimize button. This helps instill a feeling of familiarity in our users when they come across new instant answers and also helps reaffirm the expected results of their actions, eg. all blue, underlined text should always open a link when the user clicks it
 
 Furthermore, as a largely open-source project, we like to keep our code as consistent as our instant answers. This means all code should be formatted the same way and should look and feel as though it has all been written by the same person.

--- a/duckduckhack/submitting-your-instant-answer/making_a_pull_request.md
+++ b/duckduckhack/submitting-your-instant-answer/making_a_pull_request.md
@@ -1,7 +1,9 @@
 ## Making a Pull Request
 
 Now that you have completed the [developer checklist](https://dukgo.com/duckduckhack/developer_checklist) and added [Metadata](https://dukgo.com/duckduckhack/metadata) to your instant answer, you are ready to submit a pull request.
+
 <!-- /summary -->
+
 If you are not sure how to create a pull request, GitHub provides excellent [instructions](https://help.github.com/articles/creating-a-pull-request).
 
 The root of each repository contains a `pull_request_template` which includes the most common questions the team will have about your contribution. The contents of this file should be copied and pasted directly into the [description area](https://github-images.s3.amazonaws.com/help/pull_requests/pullrequest-description.png) of the GitHub pull request form. The completed template will help the community better understand your pull request and expedite the review process.

--- a/duckduckhack/submitting-your-instant-answer/metadata.md
+++ b/duckduckhack/submitting-your-instant-answer/metadata.md
@@ -67,7 +67,9 @@ secondary_example_queries "r/accounting";
 ## category
 
 The category into which your instant answer best fits.
+
 <!-- /summary -->
+
 Supported categories include:
 
 - bang
@@ -106,7 +108,9 @@ category "forums";
 ## topics
 
 A list of the topics to which your instant answer applies.
+
 <!-- /summary -->
+
 Supported topics include:
 
 - everyday
@@ -147,7 +151,9 @@ code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/
 ## attribution
 
 Information about you, the author.
+
 <!-- /summary -->
+
 Supported attribution sources include:
 
 - email

--- a/duckduckhack/submitting-your-instant-answer/review_process.md
+++ b/duckduckhack/submitting-your-instant-answer/review_process.md
@@ -1,7 +1,9 @@
 ## Review Process
 
 When you submit a pull request, a community leader will assign themselves to your pull request and work with you to get your instant answer live on DuckDuckGo. All comments and suggestions for your pull request should be discussed publicly in the pull request on Github, so that others can follow the progression. Of course, you can always contact anyone from the community or team if you have questions. Here are some community leaders who are available to help out: 
+
 <!-- /summary -->
+
 - [@bradcater](https://github.com/bradcater)
 - [@jdorweiler](https://github.com/jdorweiler)
 - [@kablamo](https://github.com/kablamo)

--- a/duckduckhack/testing/advanced_testing.md
+++ b/duckduckhack/testing/advanced_testing.md
@@ -108,7 +108,9 @@ Run your instant answer test file like this:
 ```txt
 perl -Ilib t/Chars.t
 ```
+
 <!-- /summary -->
+
 If successful, you should see a lot of **ok** lines.
 
 ```txt

--- a/duckduckhack/testing/installing_duckpan.md
+++ b/duckduckhack/testing/installing_duckpan.md
@@ -69,7 +69,9 @@ https://ddg-community.s3.amazonaws.com/ddh-vbox.rar
 ddh-vmw.rar:  
 MD5: 95ad9acfacadb4b0cb0cf23ffaa3516e  
 https://ddg-community.s3.amazonaws.com/ddh-vmw.rar
+
 <!-- /summary -->
+
 #### Roadmap
 
 - Docker support
@@ -78,7 +80,9 @@ https://ddg-community.s3.amazonaws.com/ddh-vmw.rar
 ### Using the Virtual Machine
 
 To use the Virtual Machine, you will need to download and install **VirtualBox**, **VMWare Workstation** or **VMWare Player**, depending on your current OS.
+
 <!-- /summary -->
+
 #### VirtualBox (free)
 
 Website: https://www.virtualbox.org/  
@@ -122,7 +126,9 @@ Once you have installed the virtual machine you should be able to start up the V
 The Vagrant-based DuckDuckHack virtual environment provides a similar sandbox to the DuckDuckHack VM, but rather than downloading a prebuilt VM, Vagrant creates an environment for you based on the defined configuration.  Vagrant is an awesome tool for building development environments.  One command - `vagrant up` - gets you a complete working environment in minutes.  Something go wrong with the environment?  No messing around with snapshots.  Tear the VM down and build a fresh environment.  The DuckDuckHack Vagrant environment uses Chef cookbooks and the DuckPAN installer script, so configuration is transparent and easily shared.
 
 Through the Vagrant configuration, you can easily switch back and forth between a headless-mode and the traditional VirtualBox interface.  The configuration defaults to headless.
+
 <!-- /summary -->
+
 ### Setup Instructions
 
 1. Install: [Vagrant](http://docs.vagrantup.com/v2/installation/index.html) and [Bundler](http://bundler.io/#getting-started)
@@ -174,7 +180,9 @@ To install DuckPAN, open your terminal and run:
 ```shell
 curl http://duckpan.org/install.pl | perl
 ```
+
 <!-- /summary -->
+
 [This script](https://github.com/duckduckgo/p5-duckpan-installer) will setup [local::lib](https://metacpan.org/module/local::lib), which is a way to install Perl modules without changing your base Perl installation. If you already use local::lib or [perlbrew](https://metacpan.org/module/perlbrew), don't worry, this script will intelligently use what you already have.
 
 If you didn't have a local::lib before running the install script, you will need to run the script twice. It should tell you when like this:

--- a/duckduckhack/testing/test_files.md
+++ b/duckduckhack/testing/test_files.md
@@ -1,6 +1,8 @@
 ## Test Files
 Good test files can help you quickly test code iterations. They also serve as a functional specification for your code. This specification helps everyone quickly understand and verify the expected behavior of the tested code, improving the quality of the feedback you receive and accelerating the review process.
+
 <!-- /summary -->
+
 Every instant answer must include a test file in the `t` directory. The test files are run automatically before each release to ensure that all instant answers are functioning properly. Properly functioning instant answers:
 
 - ignore any unsuitable queries,
@@ -24,7 +26,9 @@ Tests are run from the root of the repository using the `prove` command included
 ```shell
 prove -Ilib t/TestName.t
 ```
+
 <!-- /summary -->
+
 Or all of the tests in the repository's `t` directory:
 
 ```shell

--- a/duckduckhack/testing/testing_location_api.md
+++ b/duckduckhack/testing/testing_location_api.md
@@ -1,7 +1,9 @@
 ## Testing with the Location API
 
 To write a test for a location-aware instant answer, you'll need to pass the test function an extra parameter - a `DDG::Request` object, with the location specified. To do this, you'll need to `use DDG::Test::Location` and `use DDG::Request`. Here is a working annotated example excerpted from the **Goodie::HelpLine** test file `t/HelpLine.t`. The same process should be used for Spice.
+
 <!-- /summary -->
+
 Note that only a small set of locations are available to be simulated for testing. They are defined in [DDG::Test::Location.pm](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Test/Location.pm#L18).
 
 


### PR DESCRIPTION
Mostly to fix small problems they cause for the Github markdown parser. Also because it looks a little nicer

cc// @jdorweiler 
