### PR TITLE
Add a note about attribution metadata

### DIFF
--- a/duckduckhack/submitting-your-instant-answer/metadata.md
+++ b/duckduckhack/submitting-your-instant-answer/metadata.md
@@ -169,8 +169,11 @@ If a single string is given, it will be used to create a link to the defined pro
 
 When an array reference is provided, the first element will be used to create the link while the second will be used as the text for the link.
 
+The same attribution type can appear multiple times if necessary, for example when there is more than one contibutor.
+
 ```perl
 attribution twitter => "mithrandiragain",
             github  => ["MithrandirAgain", "Gary Herreman"],
-            web     => ['http://atomitware.tk/mith', 'MithrandirAgain'];
+            web     => ['http://atomitware.tk/mith', 'MithrandirAgain'],
+            github  => ["jarmokivekas", "Jarmo Kivekäs"];
 ```


### PR DESCRIPTION
A small detail I ran across recently. It wasn't obvious how to add more contributors to the attribution, e.g when updating someone else's instant answer.

I saw it done this way in some of the goodies. This is the correct way, isn't it?
