### PR TITLE
Special symbol rendering errors

### DIFF
--- a/duckduckhack/submitting-your-instant-answer/metadata.md
+++ b/duckduckhack/submitting-your-instant-answer/metadata.md
@@ -175,5 +175,5 @@ The same attribution type can appear multiple times if necessary, for example wh
 attribution twitter => "mithrandiragain",
             github  => ["MithrandirAgain", "Gary Herreman"],
             web     => ['http://atomitware.tk/mith', 'MithrandirAgain'],
-            github  => ["jarmokivekas", "Jarmo Kivekäs"];
+            github  => ["jarmokivekas", "Jarmo Kivekas"];
 ```


### PR DESCRIPTION
In pull request #136 I added my name as an example to the metadata attribution example. The letter `ä` in `Kivekäs` is rendered as `Ã¤` on the live website. This is a common encoding error for that specific character (`&auml;` in html) when not using utf-8. 

Since the english language uses _very_ little scandinavian letters the simple workaround is just replacing it with a regular `a` and be done with it (Done is this PR).

It might be worthwhile to note that at least some part of the pipline form git to live site is not utf-8 enabled. Not a very important note for en english language site, perhaps. As a scandinavian I'm just used to doing everything in utf-8.

Silly languages with their own alphabets...
