### PR TITLE
Fix Dead Links to Example IA's on GitHub

### DIFF
--- a/duckduckhack/getting-started/whatsnew.md
+++ b/duckduckhack/getting-started/whatsnew.md
@@ -150,4 +150,4 @@ Because APIs define their data in their own ways, instant answers that use built
 [Spice]: https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/spice/spice_overview.md
 [Goodies]: https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/goodie/goodie_overview.md
 [Fathead]: https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/fathead/fathead_overview.md
-[triggers]:https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/goodie/goodie_triggers.md
+[triggers]:https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/spice/spice_triggers.md


### PR DESCRIPTION
Example links provided were using the incorrect/deleted tree "bttf" changed to "master" tree.
