### PR TITLE
Zaahir/quickstart fix

### DIFF
--- a/duckduckhack/goodie/goodie_quickstart.md
+++ b/duckduckhack/goodie/goodie_quickstart.md
@@ -346,7 +346,7 @@ At this point you're done the tutorial, but we have a bonus surprise for you...
 
 ## Bonus - See Your Instant Answer live on DuckDuckGo.com
 
-1. Open "**GitHubUsername.pm**" in the editor and change the **`Metadata`** to this:
+1. Open "**GitHubUsername.pm**" in the editor and change the **`Metadata`** (lines 11-20) to this:
 
     ```perl
     name "IsAwesome GitHubUsername";


### PR DESCRIPTION
Small update to match most recent Goodie template. I've noticed two people make the same mistake (leaving in `return $_;` in the handle before their own return) and I have no idea how it's happening.

Hopefully this will help a little.

//cc @zekiel @mwmiller 
