### PR TITLE
add comment to explain initial return in IsAwesome Goodies

### DIFF
--- a/duckduckhack/goodie/goodie_quickstart.md
+++ b/duckduckhack/goodie/goodie_quickstart.md
@@ -315,7 +315,7 @@ Now we're going to create our first Goodie! We'll be using the DuckPAN tool to g
 
     ```perl
     handle remainder => sub {
-        return if $_;
+        return if $_; # if we have a remainder (i.e. query != trigger), bail out
         return "GitHubUsername is awesome and has successfully completed the DuckDuckHack Goodie tutorial!";
     };
     ```


### PR DESCRIPTION
//cc @mwmiller 

I managed to think that return was a mistake and then later realized what it's for. Alternatively I could rewrite the code to something like:
```perl
return "GitHubUsername is awesome..." unless $_;
return;
```

But I think you prefer bailing earlier, rather than later?