### PR TITLE
spice_attributes.md - Update Spice `to` and `from`

### DIFF
--- a/duckduckhack/spice/spice_attributes.md
+++ b/duckduckhack/spice/spice_attributes.md
@@ -2,11 +2,31 @@
 
 ## Spice `to`
 
-(Know what should go here? Then **please** [contribute to the documentation](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/CONTRIBUTING.md)!)
+This attribute defines the API endpoint for your Instant Answer. E.g.
+
+``` perl
+spice to => 'http://example.com/search/$1?loc=$2';
+```
+
+A GET request will be made to this URL to retrieve data. The **$1** and **$2** in the URL are values captured from the regular expression defined by `spice from`, which has a default value of `(.*)`. See the full documentation of `spice from` below for more information.
 
 ## Spice `from`
 
-(Know what should go here? Then **please** [contribute to the documentation](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/CONTRIBUTING.md)!)
+The `spice from` attribute defines a regular expression which groups data returned from the `handle` function. All parameters returned from the `handle` function in a Spice are converted into strings and joined with a `/`. Here's an example:
+
+``` perl
+handle remainder => sub {
+  # Produces the string "foo/bar/baz"
+  return "foo", "bar", "baz";
+}
+
+# Captures three groups separated by a forward slash
+spice from => '(.*)/(.*)/(.*)';
+```
+
+In the above example, the values returned from `handle` are passed to `spice from` as "foo/bar/baz", which then matches the regex and passes the parameters to `spice to`, where `$1 = "foo"`, `$2 = "bar"`, and `$3 = "baz"`. `spice to` then uses these parameters to handle the API request.
+
+By default, `spice from` has a value of `(.*)`, which sends all parameters from the `handle` function to `spice to` in a single group, **$1**.
 
 ## Spice `wrap_jsonp_callback`
 


### PR DESCRIPTION
Adds documentation for the Spice `to` attribute.

Most of the verbiage was borrowed from https://duck.co/duckduckhack/spice_basic_tutorial.