### PR TITLE
Fix product_details template image link

### DIFF
--- a/duckduckhack/spice/spice_templates_overview.md
+++ b/duckduckhack/spice/spice_templates_overview.md
@@ -652,7 +652,7 @@ templates: {
 
 ### Template Diagram
 
-![products_detail template](https://images.duckduckgo.com/iu/?u=%3A%2F%2Fraw.githubusercontent.com%2Fduckduckgo%2Fduckduckgo-documentation%2Fmaster%2Fduckduckhack%2Fassets%2Fdiagrams%2Fproducts_detail.png&f=1)
+![products_detail template](https://images.duckduckgo.com/iu/?u=https%3A%2F%2Fraw.githubusercontent.com%2Fduckduckgo%2Fduckduckgo-documentation%2Fmaster%2Fduckduckhack%2Fassets%2Fdiagrams%2Fproducts_detail.png&f=1)
 
 <!-- /summary -->
 


### PR DESCRIPTION
`https` is missing from the `products_detail template` image link in spice_templates_overview.md

Edit: @jbarrett :smile: [commit](https://github.com/duckduckgo/duckduckgo-documentation/pull/172/files#diff-efe5dcd3d094634a403f8f557c14f589R653)

CC @moollaza 