### PR TITLE
Updating Links

### DIFF
--- a/duckduckhack/goodie/goodie_advanced_handle_functions.md
+++ b/duckduckhack/goodie/goodie_advanced_handle_functions.md
@@ -31,10 +31,18 @@ return "Text output",
 ```
 
 Realistic examples are scattered through the Goodie Repository:
+<<<<<<< HEAD
  * [Calculator](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Calculator.pm#L155...L162)
  * [GUID](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/GUID.pm#L47..L52)
  * [URLDecode](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/URLDecode.pm#L45..L50)
 
+=======
+
+ - [Calculator](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Calculator.pm#L153-L161)
+ - [GUID](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/GUID.pm#L46-L52)
+ - [URLDecode](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/URLDecode.pm#L49-L55)
+ 
+>>>>>>> Docs: Update links in advanced_handle_functions
 ## Using Files in the Share Directory
 
 Goodies can use simple text or html input files for display or processing. These files can be read once and reused to answer many queries without cluttering up your source code.
@@ -76,11 +84,10 @@ As with the Passphrase Goodie example above, each line becomes an entry in the r
 
 In some cases, you may need to generate the data files you will `slurp` from the share directory. If so, please put the required generation scripts in the Goodie's `share` directory. While **shell scripts are preferred**, your scripts can be written in the language of your choice.
 
-As an example, the [CurrencyIn Goodie](https://github.com/duckduckgo/zeroclickinfo-goodies/tree/master/share/goodie/currency_in) uses a [combination of Shell and Python scripts](https://github.com/duckduckgo/zeroclickinfo-goodies/tree/master/share/goodie/currency_in) to generate its input data, `currency.txt`.
+As an example, the [CurrencyIn Goodie](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/CurrencyIn.pm) uses a [combination of Shell and Python scripts](https://github.com/duckduckgo/zeroclickinfo-goodies/tree/master/share/goodie/currency_in) to generate its input data, `currency.txt`.
 
 ## Stylesheets
 
 Goodies can load custom stylesheets by adding a `.css` file to their `share` directory, with a filename identical to the parent directory. Goodie stylesheets will be automatically included along with the Goodie's output when triggered. For example, the [RegexCheatSheet Goodie](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/RegexCheatSheet.pm) uses the directory `share/goodie/regex_cheat_sheet` which contains a [custom stylesheet](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/share/goodie/regex_cheat_sheet/regex_cheat_sheet.css).
 
-**Note:** Custom stylesheets should be used sparingly and only when absolutely necessary. 
-
+**Note:** Custom stylesheets should be used sparingly and only when absolutely necessary.

--- a/duckduckhack/goodie/goodie_advanced_handle_functions.md
+++ b/duckduckhack/goodie/goodie_advanced_handle_functions.md
@@ -31,18 +31,11 @@ return "Text output",
 ```
 
 Realistic examples are scattered through the Goodie Repository:
-<<<<<<< HEAD
- * [Calculator](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Calculator.pm#L155...L162)
- * [GUID](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/GUID.pm#L47..L52)
- * [URLDecode](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/URLDecode.pm#L45..L50)
-
-=======
 
  - [Calculator](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Calculator.pm#L153-L161)
  - [GUID](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/GUID.pm#L46-L52)
  - [URLDecode](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/URLDecode.pm#L49-L55)
  
->>>>>>> Docs: Update links in advanced_handle_functions
 ## Using Files in the Share Directory
 
 Goodies can use simple text or html input files for display or processing. These files can be read once and reused to answer many queries without cluttering up your source code.

--- a/duckduckhack/goodie/goodie_helpers.md
+++ b/duckduckhack/goodie/goodie_helpers.md
@@ -87,7 +87,7 @@ Also available for use are:
 
 ## HTML Encoding
 
-In all situations when the query string is output as HTML, it ***must be encoded***; this is important for protection from XSS (cross site scripting) attacks. There is a handy helper available for Goodies in the form of:
+In all situations when the query string is output as HTML, it ***must be encoded***; this is important for protection from [cross-site scripting attacks](https://duckduckgo.com/Cross-site_scripting?ia=about). There is a handy helper available for Goodies in the form of:
 
 ```perl
 # simple scalar:

--- a/duckduckhack/submitting-your-instant-answer/developer_checklist.md
+++ b/duckduckhack/submitting-your-instant-answer/developer_checklist.md
@@ -19,7 +19,7 @@ Before submitting your Instant Answer, please go over this checklist to make sur
     - Did you set `is_unsafe` to true?
 
 - Can this Instant Answer return an HTML response?
-    - Have you guaranteed that the response does not contain unsanitized user-supplied strings (e.g., the query string) which could lead to [cross-site scripting attacks](https://www.owasp.org/index.php/Cross-site_Scripting_%28XSS%29)?
+    - Have you guaranteed that the response does not contain unsanitized user-supplied strings (e.g., the query string) which could lead to [cross-site scripting attacks](https://duckduckgo.com/Cross-site_scripting?ia=about)?
 
 ## Spice
 


### PR DESCRIPTION
Small Updates:
+ Fix `Realistic examples are scattered through the Goodie Repository:` list formatting, update links to point to the structured answer.  
**Current:**
![selection_127](https://cloud.githubusercontent.com/assets/5282264/5887108/184d0d22-a3fa-11e4-9557-649a15762428.png)

+ Update first `CurrencyIn Goodie` to point to .pm file

+ Update other cross-site scripting attacks links to point to DDG