### PR TITLE
Language API docs

### DIFF
--- a/duckduckhack/advanced/language_api.md
+++ b/duckduckhack/advanced/language_api.md
@@ -1,12 +1,8 @@
 ## Language API
 
-While at the moment DuckDuckGo only accepts Instant Answers in English, it sometimes might be useful to know a user's locale. For instance, it is currently used by the [Translation](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Translate/FromTo.pm) Instant Answer.
-
-Keep in mind the locale's language might not necessarily be the user's preferred language.
+The [core DDG library](https://github.com/duckduckgo/duckduckgo) exposes a Language API which Goodie and Spice Instant Answers can access in their `handle` functions. The location data is contained in the `$lang` variable.
 
 <!-- /summary -->
-
-The [core DDG library](https://github.com/duckduckgo/duckduckgo) exposes a Language API which Goodie and Spice Instant Answers can access in their `handle` functions. The location data is contained in the `$lang` variable.
 
 `$lang` refers to a [Language object](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Language.pm) with the following properties:
 
@@ -26,8 +22,8 @@ Example data from `$lang`:
 'flagicon'        => 'us'
 ```
 
+**Note**: The user's locale does not imply their preferred language. It simply provides the locale based on the user's IP. Thus, the locale should not be used to determine the display language for an Instant Answer.
+
 When testing interactively with `duckpan`, the locale will always be set to `en_US`.
 
 It is possible to set different locales when running automated tests. Please refer to the [Language API testing guide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/testing_language_api.md) for more information.
-
-When your Instant Answer goes live, `$lang` will refer to the user's chosen locale.

--- a/duckduckhack/advanced/language_api.md
+++ b/duckduckhack/advanced/language_api.md
@@ -1,0 +1,33 @@
+## Language API
+
+While at the moment DuckDuckGo only accepts Instant Answers in English, it sometimes might be useful to know a user's locale. For instance, it is currently used by the [Translation](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Translate/FromTo.pm) Instant Answer.
+
+Keep in mind the locale's language might not necessarily be the user's preferred language.
+
+<!-- /summary -->
+
+The [core DDG library](https://github.com/duckduckgo/duckduckgo) exposes a Language API which Goodie and Spice Instant Answers can access in their `handle` functions. The location data is contained in the `$lang` variable.
+
+`$lang` refers to a [Language object](https://github.com/duckduckgo/duckduckgo/blob/master/lib/DDG/Language.pm) with the following properties:
+
+```perl
+my @language_attributes = qw( flagicon flag_url name_in_local rtl locale nplurals name_in_english);
+```
+
+Example data from `$lang`:
+
+```perl
+'nplurals'        => 2,
+'name_in_local'   => 'English of United States',
+'rtl'             => 0,
+'flag_url'        => 'https://duckduckgo.com/f2/us.png',
+'name_in_english' => 'English of United States',
+'locale'          => 'en_US',
+'flagicon'        => 'us'
+```
+
+When testing interactively with `duckpan`, the locale will always be set to `en_US`.
+
+It is possible to set different locales when running automated tests. Please refer to the [Language API testing guide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/testing_language_api.md) for more information.
+
+When your Instant Answer goes live, `$lang` will refer to the user's chosen locale.

--- a/duckduckhack/ddh-index.md
+++ b/duckduckhack/ddh-index.md
@@ -50,6 +50,7 @@
   - [Test Files](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/test_files.md)
   - [Advanced](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/advanced_testing.md)
   - [Testing with the Location API](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/testing_location_api.md)
+  - [Testing with the Language API](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/testing/testing_language_api.md)
 
 - **Submitting Your Instant Answer**
   - [Preparing for a Pull Request](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/submitting-your-instant-answer/preparing_for_a_pull_request.md)
@@ -60,6 +61,7 @@
 
 - **Advanced**
   - [Location API](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/advanced/location_api.md)
+  - [Language API](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/advanced/language_api.md)
 
 - **Resources**
   - [Common Pitfalls](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/resources/common_pitfalls.md)

--- a/duckduckhack/ddh-prev-next.json
+++ b/duckduckhack/ddh-prev-next.json
@@ -171,11 +171,16 @@
 
 	"testing_location_api.md": {
 		"prev": ["advanced_testing.md"],
+		"next": ["testing_language_api.md"]
+	},
+
+	"testing_language_api.md": {
+		"prev": ["testing_location_api.md"],
 		"next": []
 	},
 
 	"preparing_for_a_pull_request.md" : {
-		"prev" : ["testing_location_api.md"],
+		"prev" : ["testing_language_api.md"],
 		"next" : ["review_process.md"]
 	},
 
@@ -201,6 +206,11 @@
 
 	"location_api.md": {
 		"prev": [],
+		"next": ["language_api.md"]
+	},
+
+	"language_api.md": {
+		"prev": ["location_api.md"],
 		"next": []
 	},
 

--- a/duckduckhack/testing/testing_language_api.md
+++ b/duckduckhack/testing/testing_language_api.md
@@ -1,0 +1,36 @@
+## Testing with the Language API
+
+To write a test for a locale-aware Instant Answer, you'll need to pass the test function an extra parameter - a `DDG::Request` object, with the location specified. To do this, you'll need to `use DDG::Test::Language` and `use DDG::Request`. Here is a quick annotated example testing the language detect feature of the [Translate](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/Translate/Detect.pm) Instant Answer:
+
+```perl
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Spice;
+
+# These two modules are only necessary when testing with the Language API.
+use DDG::Test::Language;
+use DDG::Request;
+
+ddg_spice_test(
+    ["DDG::Spice::Translate::Detect"],
+    # This optional argument to ddg_spice_test is a DDG::Request oject.
+    # The two arguments we pass to the constructor are:
+    # the query we're testing against
+    # language object, created by calling test_language with a country code
+
+    # Note that the only supported values for test_language are:
+    # "us" (US English), "de" (German) and "my" (Malay)
+    DDG::Request->new(
+        query_raw => "translate good",
+        language => test_language("de"),
+    ), test_spice(
+        '/js/spice/translate/detect/good/de',
+        caller => "DDG::Spice::Translate::Detect"
+    )
+);
+
+done_testing;
+```

--- a/duckduckhack/testing/testing_location_api.md
+++ b/duckduckhack/testing/testing_location_api.md
@@ -1,6 +1,6 @@
 ## Testing with the Location API
 
-To write a test for a location-aware Instant Answer, you'll need to pass the test function an extra parameter - a `DDG::Request` object, with the location specified. To do this, you'll need to `use DDG::Test::Location` and `use DDG::Request`. Here is a working annotated example excerpted from the **Goodie::HelpLine** test file `t/HelpLine.t`. The same process should be used for Spice.
+To write a test for a location-aware Instant Answer, you'll need to pass the test function an extra parameter - a `DDG::Request` object, with the location specified. To do this, you'll need to `use DDG::Test::Location` and `use DDG::Request`. Here is a working annotated example excerpted from the [Spice::Snow](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/t/Snow.t) Instant Answer test file. The same process should be used for Goodies.
 
 <!-- /summary -->
 
@@ -21,7 +21,7 @@ use DDG::Request;
 
 ddg_spice_test(
     [qw( DDG::Spice::Snow )],
-    # This optional argument to ddg_goodie_test is a DDG::Request object.
+    # This optional argument to ddg_spice_test is a DDG::Request object.
     # The object constructor takes two arguments of its own:
     # the query (usually specified in the test_zci),
     # and a location object - created by test_location (with a country code).


### PR DESCRIPTION
Fixes #180.

I think I've covered things reasonably well (including how to test with the Language API), but this is probably more of a WIP at the moment.

I was also wondering whether to include a link to [this document](https://github.com/duckduckgo/duckduckgo/blob/d38c71e6a269ec87441a62e87593a89398182e4a/lib/DDG/Manual/Translation.pod) which seems to describe things pretty well (especially `nplurals`, which baffled me when I saw it for the first time).

I also noticed that the IA referred to in `testing_location_api.md` was incorrect, so I added a fix.