### PR TITLE
Spice Advanced Frontend: fix incorrect regex in example

### DIFF
--- a/duckduckhack/spice/spice_advanced_frontend.md
+++ b/duckduckhack/spice/spice_advanced_frontend.md
@@ -42,7 +42,7 @@ If you're returning multiple values in your backend `handle` function, you may n
 ```
 // our JSONP response has src like "/js/spice/example_answer/term1/term2"
 
-var matches = source.match(/example_answer\/([^\/]+)/([^\/]+)),
+var matches = source.match(/example_answer\/([^\/]+)\/([^\/]+)/),
     partOne = matches[1], // equals "term1"
     partTwo = matches[2]; // equals "term2"
 ```


### PR DESCRIPTION
Just noticed I botched up the regex in the example at the bottom.

It's a lot easier to spot when you've got [syntax highlighting](https://duck.co/duckduckhack/spice_advanced_frontend) on...