### PR TITLE
Reflect move of share subdirs for fatheads

### DIFF
--- a/duckduckhack/fathead/fathead_basic_tutorial.md
+++ b/duckduckhack/fathead/fathead_basic_tutorial.md
@@ -42,7 +42,7 @@ icon_url "/i/www.github.com.ico";
 
 source "GitHub";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/hello_world";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/hello_world";
 
 topics "geek", "programming";
 
@@ -82,7 +82,7 @@ icon_url "/i/www.github.com.ico";
 
 source "GitHub";
 
-code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/hello_world";
+code_url "https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead/hello_world";
 
 topics "geek", "programming";
 
@@ -98,13 +98,13 @@ attribution
 
 ## Step 2: Create a directory
 
-Every Fathead has a directory under share/ that contains all files except the one we just created. The name of the directory must be the name of the Perl module converted to [snake case](https://en.wikipedia.org/wiki/Snake_case). For this tutorial, we'll use `share/hello_world/`.
+Every Fathead has a directory under share/fathead/ that contains all files except the one we just created. The name of the directory must be the name of the Perl module converted to [snake case](https://en.wikipedia.org/wiki/Snake_case). For this tutorial, we'll use `share/fathead/hello_world/`.
 
 ## Step 3: Write the fetch.sh script
 
 Every Fathead Instant Answer requires a `fetch.sh` file. This shell script is invoked to fetch the remote data that we need in order to generate our output. For example, following script will clone a git repository that contains a collection of hello world source files:
 
-###### share/hello_world/fetch.sh
+###### share/fathead/hello_world/fetch.sh
 
 ```shell
 #!/bin/sh
@@ -114,7 +114,7 @@ git clone git://github.com/leachim6/hello-world.git download
 
 In this case, the git repository is just a collection of source files; we'll need to do some parsing in order to get it into the format we need. Note that *git clone* is not the only way to fetch data. Most Fatheads use *curl* or *wget*.
 
-**Also Note:** All temporary files should be placed in the `download/` subdirectory within your Fathead's directory. For this example, that means `share/hello_world/download/`. *git* creates this subdirectory for us, but if your plugin uses a different tool, you make have to include `mkdir download` in your fetch script.
+**Also Note:** All temporary files should be placed in the `download/` subdirectory within your Fathead's directory. For this example, that means `share/fathead/hello_world/download/`. *git* creates this subdirectory for us, but if your plugin uses a different tool, you make have to include `mkdir download` in your fetch script.
 
 ## Step 4: Write the parsing script
 
@@ -122,11 +122,11 @@ The data we just fetched needs to be parsed before we can use it, so we'll write
 
 **Note:** Our machines are running **Ubuntu 12.04**. These are the machines that will be used to test and run your parser, so **please make sure your language and dependencies are compatible with our environment**.
 
-Since Fatheads can have vastly different data sources, we can't tell you what is the best approach to parsing. We suggest you look through the [Fathead repository](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share) to get ideas from other developers.
+Since Fatheads can have vastly different data sources, we can't tell you what is the best approach to parsing. We suggest you look through the [Fathead repository](https://github.com/duckduckgo/zeroclickinfo-fathead/tree/master/share/fathead) to get ideas from other developers.
 
 For the purposes of this tutorial, we're going to use Python to parse the git repository we just cloned.
 
-###### share/hello_world/parse.py
+###### share/fathead/hello_world/parse.py
 
 ```python
 if __name__ == "__main__":

--- a/duckduckhack/fathead/fathead_overview.md
+++ b/duckduckhack/fathead/fathead_overview.md
@@ -10,19 +10,19 @@ Each Fathead Instant Answer has its own directory, which looks like this:
 
 - ``lib/DDG/Fathead/FatheadName.pm`` &ndash; a Perl file that lists some meta information about the Instant Answer
 
-- ``share/fathead_name/fetch.sh`` &ndash; a shell script called to fetch the data.
+- ``share/fathead/fathead_name/fetch.sh`` &ndash; a shell script called to fetch the data.
 
-- ``share/fathead_name/download/`` &ndash; a directory to hold temp files created by fetch.sh
+- ``share/fathead/fathead_name/download/`` &ndash; a directory to hold temp files created by fetch.sh
 
-- ``share/fathead_name/parse.xx`` &ndash; the script used to parse the data once it has been fetched. .xx can be .pl, .py, .rb, .js, etc. depending on what language you use.
+- ``share/fathead/fathead_name/parse.xx`` &ndash; the script used to parse the data once it has been fetched. .xx can be .pl, .py, .rb, .js, etc. depending on what language you use.
 
-- ``share/fathead_name/parse.sh`` &ndash; a shell script wrapper around parse.xx
+- ``share/fathead/fathead_name/parse.sh`` &ndash; a shell script wrapper around parse.xx
 
-- ``share/fathead_name/README.txt`` &ndash; Please include any dependencies here, or other special instructions for people trying to run it. Currently, Fathead Instant Answers require some hand work by DuckDuckGo staff during integration.
+- ``share/fathead/fathead_name/README.txt`` &ndash; Please include any dependencies here, or other special instructions for people trying to run it. Currently, Fathead Instant Answers require some hand work by DuckDuckGo staff during integration.
 
-- ``share/fathead_name/output.txt`` &ndash; the output file. It generally should **not** be committed to github, but may be committed if it is small (<1MB).
+- ``share/fathead/fathead_name/output.txt`` &ndash; the output file. It generally should **not** be committed to github, but may be committed if it is small (<1MB).
 
-- ``share/fathead_name/data.url`` &ndash; an optional pointer to a URL in the cloud somewhere, which contains the data to process.
+- ``share/fathead/fathead_name/data.url`` &ndash; an optional pointer to a URL in the cloud somewhere, which contains the data to process.
 
 
 ## Data File Format


### PR DESCRIPTION
In commit 7acff19cb01437db34dea1c0d41e5bceb0e5c627 of
zeroclickinfo-fathead, the subdirectories of share got moved into
share/fathead. We update the documentation to reflect this move too.