### PR TITLE
Clarify to use \n as line separator in code snippets

### DIFF
--- a/duckduckhack/fathead/fathead_overview.md
+++ b/duckduckhack/fathead/fathead_overview.md
@@ -105,6 +105,12 @@ If you want to include a code snippet or another pre-formatted example in the ab
 <pre><code>code block goes here</code></pre>
 ```
 
+For multiline code snippets, use only `\n` to separate lines:
+
+```html
+<pre><code>foo\nbar\nbaz</code></pre>
+```
+
 ## Notes
 
 There should be no duplicates in the `$page` (first) variable. If you have multiple things named the same thing you have a number of options:


### PR DESCRIPTION
According to

  https://github.com/duckduckgo/zeroclickinfo-fathead/pull/116#issuecomment-76481539

line breaks within code snippets should be encoded as \n. Since other
parts of the TSV seem to allow both \n and <br>, we clarify that
within code snippets, only \n should be used to separate lines.