### PR TITLE
Adding `use strict` to IsAwesome Goodie Template

### DIFF
--- a/duckduckhack/goodie/goodie_quickstart.md
+++ b/duckduckhack/goodie/goodie_quickstart.md
@@ -153,6 +153,7 @@ Now we're going to create our first Goodie! We'll be using the DuckPAN tool to g
     # to Instant Answer development
 
     use DDG::Goodie;
+    use strict;
 
     zci answer_type => "is_awesome_git_hub_username";
     zci is_cached   => 1;


### PR DESCRIPTION
Should force language detection as Perl 5 rather than Perl 6