### PR TITLE
Highlight that auto-templating for goodies only works for <3 items

### DIFF
--- a/duckduckhack/goodie/goodie_advanced_handle_functions.md
+++ b/duckduckhack/goodie/goodie_advanced_handle_functions.md
@@ -30,6 +30,8 @@ return "Text output",
 };
 ```
 
+While `input` can be a list of items, auto-templating will only work if it has less than 3 items.
+
 Realistic examples are scattered through the Goodie Repository:
 
  - [Calculator](https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Calculator.pm#L153-L161)


### PR DESCRIPTION
Highlight that auto-templating for goodies only works for <3 items

This has been pointed out by @zachthompson in:
https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1055#discussion_r26614782