### PR TITLE
spice_displaying.md - Fix incorrect word

### DIFF
--- a/duckduckhack/spice/spice_displaying.md
+++ b/duckduckhack/spice/spice_displaying.md
@@ -384,7 +384,7 @@ primary: [
     // for DDG.isRelevant
 
     { key: 'short_desc' }
-    // this is an extra "key" which servers as a fallback. This means if
+    // this is an extra "key" which serves as a fallback. This means if
     // either the 'name' or 'short_desc' or relevant the item is considered
     // relevant
 ],


### PR DESCRIPTION
Tiny fix

+ "servers as a fallback" - Incorrect  
+ "serves as a fallback" - Correct