### PR TITLE
Replaced Capitalize with Uppercase

### DIFF
--- a/duckduckhack/goodie/goodie_overview.md
+++ b/duckduckhack/goodie/goodie_overview.md
@@ -4,7 +4,7 @@
 
 Goodies are pure-code Instant Answers. They are essentially a Perl function that is evaluated on our servers, and do not make external HTTP requests to other services.
 
-Goodies can be extremely simple, such as the [Capitalize](https://duckduckgo.com/?q=capitalize+duckduckgo+instant+answers) Goodie, which simply uses the perl `uc` function to uppercase a string. 
+Goodies can be extremely simple, such as the [Uppercase](https://duckduckgo.com/?q=uppercase+duckduckgo+instant+answers) Goodie, which simply uses the perl `uc` function to uppercase a string. 
 
 Goodies can also be extremely complex and powerful such as the [Calculator](https://duckduckgo.com/?q=%28879+*+14%29+%2F+12) or [Timezone Converter](https://duckduckgo.com/?q=4pm+EST+to+GMT) Goodies. Contributors have used Goodies to do additional cool things like [generate passwords](https://duckduckgo.com/?q=password+15+strong&ia=answer) and [create QR codes](https://duckduckgo.com/?q=qr+duckduckhack.com&ia=answer).
 


### PR DESCRIPTION
There is no Capitalize goodie right now. There is Uppercase that uses `uc` of perl.