### PR TITLE
Replacing dead links in testing_html.md

### DIFF
--- a/duckduckhack/testing/testing_html.md
+++ b/duckduckhack/testing/testing_html.md
@@ -1,6 +1,6 @@
 ## Testing HTML
 
-You should have already tested your triggers by following the [Testing triggers](https://github.com/duckduckgo/duckduckgo#testing-triggers) section. Now that you're confident your triggers are functioning properly, follow these steps to see how it looks on a live server!
+You should have already tested your triggers by following the [Testing triggers](https://duck.co/duckduckhack/testing_triggers) section. Now that you're confident your triggers are functioning properly, follow these steps to see how it looks on a live server!
 
 <!-- /summary -->
 
@@ -50,13 +50,13 @@ You should have already tested your triggers by following the [Testing triggers]
 
     - You have a JavaScript error of some kind. Internally, we like to use the JavaScript console in [Firebug](http://getfirebug.com/) to get more details.
 
-    - An external API was not called correctly. You should examine the Web server output to make sure the correct API is being called. If it's not you will need to revise your [Spice handle function](#spice-handle-functions).
+    - An external API was not called correctly. You should examine the Web server output to make sure the correct API is being called. If it's not you will need to revise your [Spice handle function](https://duck.co/duckduckhack/spice_basic_tutorial#define-the-handle-function).
 
     - An external API did not return anything. Firebug is a great help here, as well. You should be able to see the external call in your browser and examine the response.
 
 6. Tweak the display.
 
-    Once all of the processing is working properly, you will probably want to adjust your callback function to get the display just right. The [Guidelines](https://github.com/duckduckgo/duckduckgo#guidelines) have some pointers to help you along.
+    Once all of the processing is working properly, you will probably want to adjust your callback function to get the display just right. The [Display reference](https://duck.co/duckduckhack/display_reference) section has some pointers to help you along.
 
 7. Document.
 


### PR DESCRIPTION
There were some deprecated/dead links in the duckduckhack documentation. I replaced the old ones with ones that are up-to-date.

I'm unsure, though, whether the links should point to markdown files within the documentation repo or the live site? E.g:

https://duck.co/duckduckhack/spice_basic_tutorial#define-the-handle-function (live site)
vs.
https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/spice/spice_basic_tutorial.md#define-the-handle-function (probably not)
vs. 
../spice/spice_basic_tutorial.md#define-the-handle-function (relative path within the repo)
vs.
/duckdukchack/spice/spice_basic_tutorial.md#define-the-handle-function (absolute path within the repo) (this would be nice)

Will the publisher tool handle references between markdown files properly?