### PR TITLE
Added link to cheat sheet template

### DIFF
--- a/duckduckhack/submitting-your-instant-answer/submission_and_review.md
+++ b/duckduckhack/submitting-your-instant-answer/submission_and_review.md
@@ -4,6 +4,7 @@ Now that you have completed the [developer checklist](https://dukgo.com/duckduck
 
 The root of each repository contains a `pull_request_template.md` file which includes the most common questions the team will have about your contribution:
 
+- [Cheat Sheet Pull Request Template](https://raw.githubusercontent.com/duckduckgo/zeroclickinfo-goodies/master/pull_request_template_cheat_sheet.md)
 - [Goodie Pull Request Template](https://raw.githubusercontent.com/duckduckgo/zeroclickinfo-goodies/master/pull_request_template_goodie.md)
 - [Spice Pull Request Template](https://raw.githubusercontent.com/duckduckgo/zeroclickinfo-spice/master/pull_request_template_spice.md)
 - [Fathead Pull Request Template](https://raw.githubusercontent.com/duckduckgo/zeroclickinfo-fathead/master/pull_request_template_fathead.md)


### PR DESCRIPTION
To be merged if/when the cheat sheet template is publicly available (see https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1245 ).