### PR TITLE
remove leading space before table -- breaks generated HTML

### DIFF
--- a/duckduckhack/instant-answer-display/display_reference.md
+++ b/duckduckhack/instant-answer-display/display_reference.md
@@ -46,7 +46,7 @@ The `id` should match the name of your callback function. For example, if your c
 
 The name that will be used for your Instant Answer's AnswerBar tab. The Instant Answer Framework will determine the final tab name, but it's best to provide a category or topic that describes the kind of information your Instant Answer provides. Here are some examples:
 
- <table class="table table-condensed"> 
+<table class="table table-condensed"> 
     <thead>
         <tr>
             <th>Spice IA</th>


### PR DESCRIPTION
Just noticed today that the overview page is broken. Somehow this space causes the parser to incorrectly interpret the HTML.

/cc @talsraviv 
