### PR TITLE
Update ddh-intro blog post

### DIFF
--- a/duckduckhack/getting-started/ddh-intro.md
+++ b/duckduckhack/getting-started/ddh-intro.md
@@ -1,6 +1,6 @@
 # Welcome to DuckDuckHack!
 
-We are a community of DuckDuckGo users who help improve the search engine with, "Instant Answers". To get started, please [request an invite to our Slack team](mailto:QuackSlack@duckduckgo.com?subject=AddMe). You may join multiple Slack channels to discuss your Instant Answer ideas with others who may have the same interests! 
+We are a community of DuckDuckGo users who help improve the search engine with, "Instant Answers". To get started, please [request an invite to our Slack team](mailto:QuackSlack@duckduckgo.com?subject=AddMe). You may join multiple Slack channels to discuss your Instant Answer ideas with others who may have the same interests!
 
 - [Request Slack invite](mailto:QuackSlack@duckduckgo.com?subject=AddMe)
 
@@ -11,14 +11,12 @@ You may also wish to join our DuckDuckHack Dev's email list (low traffic):
 
 ## What are Instant Answers?
 
-Instant Answers help you find what you're looking for in few or zero clicks. They're placed above ads and regular search results, and they're created/maintained by you (the community). Some Instant Answers are built from pure code and others require external sources (API requests), databases, or key-value stores. The possibilities are endless but the point is to provide a perfect result for every search. 
+Instant Answers help you find what you're looking for in few or zero clicks. They're placed above ads and regular search results, and they're created/maintained by you (the community). Some Instant Answers are built from pure code and others require external sources (API requests), databases, or key-value stores. The possibilities are endless but the point is to provide a perfect result for every search.
 
 ![App search Instant Answer example](https://images.duckduckgo.com/iu/?u=https%3A%2F%2Fraw.githubusercontent.com%2Fduckduckgo%2Fduckduckgo-documentation%2Fmaster%2Fduckduckhack%2Fassets%2Fapp_search_example.png&f=1)
 
-In the above example, [Quixey](http://quixey.com/) was a source that our own DuckDuckHack Community suggested for mobile app search. Now, any time someone searches for apps on DuckDuckGo, we request information directly from Quixey to help answer the search. 
+In the above example, [Quixey](http://quixey.com/) was a source that our own DuckDuckHack Community suggested for mobile app search. Now, any time someone searches for apps on DuckDuckGo, we request information directly from Quixey to help answer the search.
 
-To see just how simple it is to contribute an Instant Answer, check out David Farrell's PerlTricks post: [Writing Instant Answers is Easy](http://perltricks.com/article/169/2015/4/20/Writing-DuckDuckGo-instant-answers-is-easy).
+To see just how simple it is to contribute an Instant Answer, check out David Farrell's PerlTricks post: [Writing DuckDuckGo plugins just got easier](http://perltricks.com/article/189/2015/8/22/Writing-DuckDuckGo-plugins-just-got-easier).
 
 In these docs, we'll show you how to build Instant Answers that can do this and more. Start by reading about [ways to contribute](https://duck.co/duckduckhack/contributing).
-
-


### PR DESCRIPTION
If you follow the [blog post link](http://perltricks.com/article/169/2015/4/20/Writing-DuckDuckGo-instant-answers-is-easy) in the dhh-intro page, there's an editor note warning about a more up to date article with an Instant Answers tutorial:
> Editor note: some of the information in this article is out of date, see our new DuckDuckGo [article](http://perltricks.com/article/189/2015/8/22/Writing-DuckDuckGo-plugins-just-got-easier) for details.

In this PR it's proposed to use the newer article's url in the docs.
